### PR TITLE
Add a notebook to check for data requirements

### DIFF
--- a/notebooks/experimental/data_check.ipynb
+++ b/notebooks/experimental/data_check.ipynb
@@ -1,0 +1,122 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data Check!\n",
+    "\n",
+    "This notebook provides a way to check our data for 2 necessary attributes before going further. Given our data examples in ceph storage, the flake analysis tool in the [AI Library](https://gitlab.com/opendatahub/ai-library) requires the following 2 conditions.  \n",
+    "\n",
+    "\n",
+    "* `example[\"status\"] == \"failure\"`\n",
+    "* `example[\"log\"] != \"[]\"`\n",
+    "\n",
+    "We can see in the flake analysis project [here](https://gitlab.com/opendatahub/ai-library/-/blob/master/flakes_train/bots/learn/data.py#L26-27) that non-failures are filtered out during data loading and prior to model training. We can also see [here](https://gitlab.com/opendatahub/ai-library/-/blob/master/flakes_train/bots/learn/extractor.py#L103-112) that the data extraction step expects a non-empty string to be transformed using a count vectorizer. If all our strings are empty, there will not be any data to encode or train our model with. Therefore, we have to ensure that we have examples in our datset that meet both these criteria, that is non-empty log messages for failed tests.        \n",
+    "\n",
+    "\n",
+    "Below we will iterate through all available data and quantify the frequency of these attributes and determine how much usable data we have to train our flake analysis model.  \n",
+    "\n",
+    "**Modification for RHV dataset**: Further analysis of the RHV dataset has shown that it uses the string \"FAILED\" instead of \"failure\". We will make that replace below.   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4314 none empty files out of 15292\n",
+      "1316 failures out of 15292\n",
+      "695 none empty failures out of 15292\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import boto3\n",
+    "import json\n",
+    "import tempfile\n",
+    "import urllib3\n",
+    "urllib3.disable_warnings()\n",
+    "\n",
+    "\n",
+    "# SET PARAMETERS TO ACCESS S3 BACKEND\n",
+    "s3Path = 'ccit'\n",
+    "s3_endpoint_url = 'https://s3.upshift.redhat.com/'\n",
+    "s3_bucket_name = 'DH-PLAYPEN'\n",
+    "\n",
+    "\n",
+    "# CREATE CONNECTION TO S3 BACKEND\n",
+    "session = boto3.Session()\n",
+    "s3 = session.resource('s3', endpoint_url=s3_endpoint_url, verify=False)\n",
+    "\n",
+    "\n",
+    "# DOWNLOAD TRAINING DATA\n",
+    "objects = []\n",
+    "bucket = s3.Bucket(name=s3_bucket_name)\n",
+    "\n",
+    "# get list of all availble objects\n",
+    "for obj in bucket.objects.filter(Prefix=s3Path):\n",
+    "    objects.append(obj.key)\n",
+    "\n",
+    "# We want to count the occurences of data points that include both non-empty logs and \"status\" == \"failure\"\"    \n",
+    "count_both = 0\n",
+    "count_failure = 0\n",
+    "count_log  = 0\n",
+    "for key in objects:\n",
+    "    obj = s3.Object(s3_bucket_name, key)\n",
+    "    contents = obj.get()['Body'].read().decode('utf-8')\n",
+    "    if contents:\n",
+    "        jcontents = json.loads(contents)\n",
+    "        if jcontents[\"log\"] != \"[]\" and jcontents[\"status\"] == \"FAILED\":\n",
+    "            count_both += 1\n",
+    "            print(count)\n",
+    "        \n",
+    "        if jcontents[\"log\"] != \"[]\":\n",
+    "            count_log += 1\n",
+    "        \n",
+    "        if jcontents[\"status\"] == \"FAILED\":\n",
+    "            count_failure += 1 \n",
+    "        else:\n",
+    "            pass\n",
+    "            \n",
+    "\n",
+    "print(f'{count_log} none empty files out of {len(objects)}')            \n",
+    "print(f'{count_failure} failures out of {len(objects)}')            \n",
+    "print(f'{count_both} none empty failures out of {len(objects)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! It looks like we have ~700 usable examples. We can know move forward with the testing. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "devenv",
+   "language": "python",
+   "name": "devenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Closes Issue #8 

This PR includes a notebook that explains the known data requirements for the AI Library Flake Analysis and simply checks the available data in ceph for these conditions. Specifically, it counts the number of occurrence of failed tests, non-empty log messages, and the number of occurrences in which both conditions are met (The data the model will train on).      
